### PR TITLE
Column order for fixin issue #5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ before_script:
 script:
   - cd tests
   - lua basic_tests.lua
+  - lua column_order_tests.lua
 
 after_success:
   - echo "Tests passed"

--- a/Dataframe.lua
+++ b/Dataframe.lua
@@ -21,6 +21,9 @@ function clone(t) -- shallow-copy a table
 end
 
 table.exact_length = function(tbl)
+	if (type(tbl) ~= 'table') then
+		return 1
+	end
   i = 0
   for k,v in pairs(tbl) do
     i = i + 1

--- a/Dataframe.lua
+++ b/Dataframe.lua
@@ -567,16 +567,21 @@ function Dataframe:_get_numerics()
 	return new_dataset
 end
 
+--
+-- get_column_no : Gets the column number of the provided column
+--
+-- ARGS: - column_name (required) [string] : the name of the column
+--
+-- RETURNS: integer
 function Dataframe:get_column_no(column_name)
-	i = 0
-	for k,v in pairs(self.dataset) do
-		i = i + 1
-		if (column_name == k) then
+	for i = 1,#self.column_order do
+		if (column_name == self.column_order[i]) then
 			return i
 		end
 	end
 	return nil
 end
+
 --
 -- to_tensor() : convert dataset to tensor
 --
@@ -587,15 +592,25 @@ end
 function Dataframe:to_tensor(filename)
 	numeric_dataset = self:_get_numerics()
 	tensor_data = nil
-	i = 1
-	for k,v in pairs(numeric_dataset) do
-		next_col =  torch.Tensor(numeric_dataset[k])
-		if (torch.isTensor(tensor_data)) then
-			tensor_data = torch.cat(tensor_data, next_col, 2)
-		else
-			tensor_data = next_col
+	count = 1
+	for col_no = 1,#self.column_order do
+		found = false
+		col_name = self.column_order[col_no]
+		for k,v in pairs(numeric_dataset) do
+			if (k == col_name) then
+				found = true
+				break
+			end
 		end
-		i=i+1
+		if (found) then
+			next_col =  torch.Tensor(numeric_dataset[col_name])
+			if (torch.isTensor(tensor_data)) then
+				tensor_data = torch.cat(tensor_data, next_col, 2)
+			else
+				tensor_data = next_col
+			end
+			count = count + 1
+		end
 	end
 
 	if filename ~= nil then

--- a/Dataframe.lua
+++ b/Dataframe.lua
@@ -927,7 +927,8 @@ function Dataframe:_to_html(options)--data, start_at, end_at, split_table)
 	if options.split_table ~= 'top' then
 		result = result.. '<tr>'
 		result = result.. '<th></th>'
-		for k,v in pairs(options.data) do
+		for i = 1,#self.column_order do
+			k = self.column_order[i]
 			result = result.. '<th>' ..k.. '</th>'
 			if n_rows == 0 then n_rows = #options.data[k] end
 		end
@@ -937,7 +938,8 @@ function Dataframe:_to_html(options)--data, start_at, end_at, split_table)
 	for i = options.start_at, options.end_at do
 		result = result.. '<tr>'
 		result = result.. '<td>'..i..'</td>'
-		for k,v in pairs(options.data) do
+		for i = 1,#self.column_order do
+			k = self.column_order[i]
 			result = result.. '<td>' ..tostring(options.data[k][i]).. '</td>'
 		end
 		result = result.. '</tr>'

--- a/Dataframe.lua
+++ b/Dataframe.lua
@@ -20,6 +20,18 @@ function clone(t) -- shallow-copy a table
 	return target
 end
 
+table.exact_length = function(tbl)
+  i = 0
+  for k,v in pairs(tbl) do
+    i = i + 1
+  end
+  return i
+end
+
+function isint(n)
+	return n == math.floor(n)
+end
+
 -- END UTILS
 
 
@@ -30,10 +42,34 @@ local Dataframe = torch.class('Dataframe')
 --
 -- Returns: a new Dataframe object
 function Dataframe:__init()
+	self:_clean{schema = true}
+	self.print = {no_rows = 10,
+								max_col_width = 20}
+end
+
+-- Private function for cleaning all data
+function Dataframe:_clean(...)
+	local args = dok.unpack(
+		{...},
+		'Dataframe._clean',
+		'Cleans and resets all data parameters',
+		{arg='schema', type='boolean', help='Also clean schema', req=false})
 	self.dataset = {}
 	self.columns = {}
-	self.schema = {}
+	self.column_order = {}
 	self.n_rows = 0
+
+  if (args.schema) then
+		self.schema = {}
+	end
+end
+
+-- Private function for copying core settings to new Dataframe
+function Dataframe:_copy_meta(to)
+	to.column_order = clone(self.column_order)
+	to.schema = clone(self.schema)
+	to.print = clone(self.print)
+	return to
 end
 
 --
@@ -48,10 +84,6 @@ end
 -- RETURNS: nothing
 --
 function Dataframe:load_csv(...)
-	self.dataset = {}
-	self.columns = {}
-	self.n_rows = 0
-
 	local args = dok.unpack(
 		{...},
 		'Dataframe.load_csv',
@@ -63,6 +95,8 @@ function Dataframe:load_csv(...)
 		{arg='skip', type='number', help='skip this many lines at start of file', default=0},
 		{arg='verbose', type='boolean', help='verbose load', default=true}
 	)
+	-- Remove previous data
+	self:_clean()
 
 	self.dataset = csvigo.load{path = args.path,
 	                           header = args.header,
@@ -72,7 +106,48 @@ function Dataframe:load_csv(...)
 	self:_clean_columns()
 	self:_refresh_metadata()
 
+	self.column_order = self:_getCsvHeaderOrder(args.path, args.separator)
 	if args.infer_schema then self:_infer_schema() end
+end
+
+-- Returns the order of the original CSV
+function Dataframe:_getCsvHeaderOrder(filepath, separator)
+	file, msg = io.open(filepath, 'r')
+	if not file then error("Could not open file") end
+  local line = file:read()
+	file:close()
+	if not line then error("Could not read line") end
+	line = line:gsub('\r', '')
+
+	line = line .. separator -- end with separator
+	if separator == ' ' then separator = '%s+' end
+	local t = {}
+	count = 0
+	local fieldstart = 1
+	repeat
+		count = count + 1
+		-- next field is quoted? (starts with "?)
+	  if string.find(line, '^"', fieldstart) then
+			local a, c
+	    local i = fieldstart
+	    repeat
+	      -- find closing quote
+	      a, i, c = string.find(line, '"("?)', i+1)
+	    until c ~= '"'  -- quote not followed by quote?
+
+	    if not i then error('unmatched "') end
+			local f = string.sub(line, fieldstart+1, i-1)
+	    t[count] = (string.gsub(f, '""', '"'))
+
+			-- Move along the line to next separator
+	    fieldstart = string.find(line, separator, i) + 1
+	  else
+	     local nexti = string.find(line, separator, fieldstart)
+	     t[count] = string.sub(line, fieldstart, nexti-1)
+	     fieldstart = nexti + 1
+	  end
+	until fieldstart > string.len(line)
+	return t
 end
 
 --
@@ -84,28 +159,49 @@ end
 -- RETURNS: nothing
 --
 function Dataframe:load_table(...)
-
-	self.dataset = {}
-	self.columns = {}
-	self.n_rows = 0
-
 	local args = dok.unpack(
 		{...},
 		'Dataframe.load_table',
 		'Imports a table directly data into Dataframe',
 		{arg='data', type='table', help='table to import', req=true},
-		{arg='infer_schema', type='boolean', help='automatically detect columns\' type', default=true}
+		{arg='infer_schema', type='boolean', help='automatically detect columns\' type', default=true},
+		{arg='column_order', type='table', help='The column order', req=false}
 	)
+	self:_clean()
 
+	count = 0
 	for k,v in pairs(args.data) do
+		count = count + 1
+		self.column_order[count] = k
 		if (type(v) ~= 'table') then
 			self.dataset[k] = {v}
 		else
 			self.dataset[k] = v
 		end
 	end
-
 	self:_clean_columns()
+
+	if (args.column_order) then
+		no_cols = table.exact_length(self.dataset)
+		assert(#args.column_order == no_cols,
+					"The length of the column order " .. #args.column_order ..
+					" should be the same as the data " .. no_cols)
+		for i = 1,no_cols do
+			assert(args.column_order[i] ~= nil, "The column order should be continous." ..
+			       " Could not find column no. " .. i)
+			found = false
+		  for k,v in pairs(self.dataset) do
+				if (k == args.column_order[i]) then
+					found = true
+					break
+				end
+			end
+			assert(found, "Could not find the order column name " .. args.column_order[i] ..
+			              " in the data columns")
+		end
+		self.column_order = args.column_order
+	end
+
 	self:_refresh_metadata()
 
 	if args.infer_schema then self:_infer_schema() end
@@ -116,7 +212,11 @@ function Dataframe:_clean_columns()
 	temp_dataset = {}
 
 	for k,v in pairs(self.dataset) do
-		temp_dataset[trim(k)] = v
+		trimmed_column_name = trim(k)
+		assert(temp_dataset[trimmed_column_name] == nil,
+		       "The column name " .. trimmed_column_name ..
+					 " appears more than once in your data")
+		temp_dataset[trimmed_column_name] = v
 	end
 
 	self.dataset = temp_dataset
@@ -528,12 +628,40 @@ function Dataframe:to_csv(...)
 end
 
 --
+-- sub() : Selects a subset of rows and returns those
+--
+-- ARGS: - start 			(optional) [number] 	: row to start at
+-- 		   - stop 			(optional) [number] 	: last row to include
+--
+-- RETURNS: Dataframe
+--
+function Dataframe:sub(...)
+	local args = dok.unpack(
+		{...},
+		'Dataframe.sub',
+		'Retrieves a subset of elements',
+		{arg='start', type='integer', help='row to start at', default=1},
+		{arg='stop', type='integer', help='row to stop at', default=self.n_rows}
+	)
+	assert(args.start <= args.stop, "Stop argument can't be less than the start argument")
+	assert(args.start > 0, "Start position can't be less than 1")
+	assert(args.stop <= self.n_rows, "Stop position can't be more than available rows")
+
+	ret = Dataframe.new()
+	for i = args.start,args.stop do
+		ret:insert(self:get_row(i))
+	end
+	ret = self:_copy_meta(ret)
+	return ret
+end
+
+--
 -- head() : only display the table's first elements
 --
 -- ARGS: - n_items 			(required) [number] 	: items to print
 -- 		 - html 			(optional) [boolean] 	: display or not in html mode
 --
--- RETURNS: table
+-- RETURNS: Dataframe
 --
 function Dataframe:head(...)
 	local args = dok.unpack(
@@ -543,28 +671,33 @@ function Dataframe:head(...)
 		{arg='n_items', type='integer', help='The number of items to display', default=10},
 		{arg='html', type='boolean', help='Display as html', default=false}
 	)
-	head = {}
-	for i = 1, args.n_items do
-		for index,key in pairs(self.columns) do
-			if type(head[key]) == 'nil' then head[key] = {} end
-			head[key][i] = self.dataset[key][i]
-		end
-	end
+	head = self:sub(1, math.min(args.n_items, self.n_rows))
 
 	if args.html then
-		itorch.html(self:_to_html{data=head})
+		itorch.html(self:_to_html{data=head.dataset})
 	else
 		return head
 	end
 end
 
 --
+-- __pairs() : overload the pairs() function. This helps the tail()/head() to behave
+--             in the same way as previously
+--
+-- ARGS: - t (required) [Dataframe]
+--
+-- RETURNS: k, v as pairs
+function Dataframe:__pairs(...)
+	return pairs(self.dataset, ...)
+end
+
+--
 -- tail() : only display the table's last elements
 --
 -- ARGS: - n_items 			(required) [number] 	: items to print
--- 		 - html 			(optional) [boolean] 	: display or not in html mode
+-- 		   - html 			(optional) [boolean] 	: display or not in html mode
 --
--- RETURNS: table
+-- RETURNS: Dataframe
 --
 function Dataframe:tail(...)
 	local args = dok.unpack(
@@ -574,21 +707,11 @@ function Dataframe:tail(...)
 		{arg='n_items', type='integer', help='The number of items to display', default=10},
 		{arg='html', type='boolean', help='Display as html', default=false}
 	)
-	tail = {}
-
-	start_pos = self.n_rows - args.n_items + 1
-	if (start_pos < 1) then
-		start_pos = 1
-	end
-	for i = start_pos, self.n_rows do
-		for index,key in pairs(self.columns) do
-			if type(tail[key]) == 'nil' then tail[key] = {} end
-			tail[key][i] = self.dataset[key][i]
-		end
-	end
+	start_pos = math.max(1, self.n_rows - args.n_items + 1)
+	tail = self:sub(start_pos)
 
 	if args.html then
-		itorch.html(self:_to_html{data=tail, start_at=self.n_rows-10+1, end_at=self.n_rows})
+		itorch.html(self:_to_html{data=tail.dataset, start_at=self.n_rows-10+1, end_at=self.n_rows})
 	else
 		return tail
 	end
@@ -853,4 +976,99 @@ function Dataframe:_update_single_row(index_row, new_row)
 	end
 
 	return row
+end
+
+function Dataframe:__tostring()
+  local no_rows = math.min(self.print.no_rows, self.n_rows)
+	max_width = self.print.max_col_width
+
+	-- Get the width of each column
+	local lengths = {}
+	for k,v in pairs(self.dataset) do
+		lengths[k] = string.len(k)
+		for i = 1,no_rows do
+			if (v[i] ~= nil) then
+				if (lengths[k] < string.len(v[i])) then
+					lengths[k] = string.len(v[i])
+				end
+			end
+		end
+	end
+
+	add_padding = function(ret, out_len, target_len)
+		if (out_len < target_len) then
+			ret = ret .. string.rep(" ", (target_len - out_len))
+		end
+		return ret
+	end
+
+	table_width = 0
+	for _,l in pairs(lengths) do
+		table_width = table_width + math.min(l, max_width)
+	end
+	table_width = table_width +
+		3 * (table.exact_length(lengths) - 1) + -- All the " | "
+		2 + -- The beginning of each line "| "
+		2 -- The end of each line " |"
+
+	add_separator = function(ret, table_width)
+		ret = ret .. "\n+" .. string.rep("-", table_width - 2) .. "+"
+		return ret
+	end
+
+	ret = add_separator("", table_width)
+	ret = ret .. "\n| "
+	for i = 0,no_rows do
+		if (i == 0) then
+			row = {}
+			for _,k in pairs(self.columns) do
+				row[k] = k
+			end
+		else
+			row = self:get_row(i)
+		end
+
+		if (i > 0) then
+			-- Underline header with ----------------
+			if (i == 1) then
+				ret = add_separator(ret, table_width)
+			end
+			ret = ret .. "\n| "
+		end
+
+		for ii = 1,#self.column_order do
+			column_name = self.column_order[ii]
+			if (ii > 1) then
+				ret = ret .. " | "
+			end
+			if (self.schema[column_name] == "number") then
+				if (row[column_name] == nil) then
+					output = "NA"
+				else
+					output = string.format(row[column_name])
+				end
+				-- Right align numbers by padding to left
+				ret = add_padding(ret, string.len(output), lengths[column_name])
+				ret = ret .. output
+			else
+				if (row[column_name] == nil) then
+					output = "NA"
+				else
+					output = row[column_name]
+				end
+				if (string.len(output) > max_width) then
+					output = string.sub(output, 1, max_width - 3) .. "..."
+				end
+				ret = ret .. output
+				-- Padd left if needed
+				ret = add_padding(ret, string.len(output), math.min(max_width, lengths[column_name]))
+			end
+		end
+		ret = ret .. " |"
+	end
+	if (self.n_rows > no_rows) then
+		ret = ret .. "\n| ..." .. string.rep(" ", table_width - 5 - 1) .. "|"
+	end
+	ret = add_separator(ret, table_width) .. "\n"
+	return ret
 end

--- a/tests/basic_tests.lua
+++ b/tests/basic_tests.lua
@@ -282,37 +282,30 @@ function df_tests.head()
   local a = Dataframe()
   a:load_csv{path = "simple_short.csv",
              verbose = false}
-  no_elmnts = 0
   head = a:head(2)
-  for k,v in pairs(head) do
-    if (#v > no_elmnts) then
-      no_elmnts = table.exact_length(v)
+  tester:eq(head.n_rows, 2,
+           "Self the n_rows isn't updated, is " .. head.n_rows ..
+           " instead of expected 2")
+  -- do a manual count
+  local no_elmnts = 0
+  for k,v in pairs(head.dataset) do
+    local l = table.exact_length(v)
+    if (l > no_elmnts) then
+      no_elmnts = l
     end
   end
-  tester:eq(no_elmnts, 2, "Expecting 2 elements got " .. no_elmnts .. " elements")
+  tester:eq(no_elmnts, 2, "Expecting 2 elements got " .. no_elmnts .. " elements when counting manually")
 
   -- Only 4 rows and thus all should be included
-  no_elmnts = 0
   head = a:head(20)
-  for k,v in pairs(head) do
-    if (#v > no_elmnts) then
-      no_elmnts = table.exact_length(v)
-    end
-  end
-  tester:eq(no_elmnts, a:shape()["rows"],
-            "The elements should be identical to the original " .. a:shape()["rows"] ..
-            " got instead " .. no_elmnts .. " elements")
+  tester:eq(head.n_rows, a.n_rows,
+            "The elements should be identical to the original " .. a.n_rows ..
+            " got instead " .. head.n_rows .. " elements")
 
-  no_elmnts = 0
   head = a:head()
-  for k,v in pairs(head) do
-    if (#v > no_elmnts) then
-      no_elmnts = table.exact_length(v)
-    end
-  end
-  tester:eq(no_elmnts, a:shape()["rows"],
-            "The elements should be identical to the original " .. a:shape()["rows"] ..
-            " as the default is < original elements. Got instead " .. no_elmnts .. " elements")
+  tester:eq(head.n_rows, a.n_rows,
+            "The elements should be identical to the original " .. a.n_rows ..
+            " as the default is < original elements. Got instead " .. head.n_rows .. " elements")
 end
 
 function df_tests.tail()
@@ -323,36 +316,33 @@ function df_tests.tail()
   local a = Dataframe()
   a:load_csv{path = "simple_short.csv",
             verbose = false}
-  no_elmnts = 0
+
   tail = a:tail(2)
-  for k,v in pairs(tail) do
+  tester:eq(tail.n_rows, 2,
+           "Self the n_rows isn't updated, is " .. tail.n_rows ..
+           " instead of expected 2")
+  -- Do a manual count
+  local no_elmnts = 0
+  for k,v in pairs(tail.dataset) do
     local l = table.exact_length(v)
     if (l > no_elmnts) then
       no_elmnts = l
     end
   end
-  tester:eq(no_elmnts, 2, "Should have selected two last elements but got " .. no_elmnts)
+  tester:eq(no_elmnts, 2,
+            "Should have selected 2 last elements but got " .. no_elmnts ..
+            " when doin a manual count")
 
   -- Only 4 rows and thus all should be included
-  no_elmnts = 0
   tail = a:tail(20)
-  for k,v in pairs(tail) do
-    local l = table.exact_length(v)
-    if (l > no_elmnts) then
-      no_elmnts = l
-    end
-  end
-  tester:eq(no_elmnts, a:shape()["rows"], "Should have selected 20 las elements and returned the original length " .. a:shape()["rows"] .. ", not " .. no_elmnts)
+  tester:eq(tail.n_rows, a.n_rows,
+            "Should have selected 20 las elements and returned the original length " ..
+            a.n_rows .. " since there are only 4 rows and not " .. tail.n_rows)
 
-  no_elmnts = 0
   tail = a:tail()
-  for k,v in pairs(tail) do
-    local l = table.exact_length(v)
-    if (l > no_elmnts) then
-      no_elmnts = l
-    end
-  end
-  tester:eq(no_elmnts, a:shape()["rows"], "Default selection is bigger than the simple_short, you got " .. no_elmnts .. " instead of " .. a:shape()["rows"])
+  tester:eq(tail.n_rows, a.n_rows,
+            "Default selection is bigger than the simple_short, you got " .. tail.n_rows ..
+            " instead of " .. a.n_rows)
 end
 
 function df_tests.show()

--- a/tests/basic_tests.lua
+++ b/tests/basic_tests.lua
@@ -286,29 +286,33 @@ function df_tests.head()
   head = a:head(2)
   for k,v in pairs(head) do
     if (#v > no_elmnts) then
-      no_elmnts = #v
+      no_elmnts = table.exact_length(v)
     end
   end
-  tester:eq(no_elmnts, 2)
+  tester:eq(no_elmnts, 2, "Expecting 2 elements got " .. no_elmnts .. " elements")
 
   -- Only 4 rows and thus all should be included
   no_elmnts = 0
   head = a:head(20)
   for k,v in pairs(head) do
     if (#v > no_elmnts) then
-      no_elmnts = #v
+      no_elmnts = table.exact_length(v)
     end
   end
-  tester:eq(no_elmnts, a:shape()["rows"])
+  tester:eq(no_elmnts, a:shape()["rows"],
+            "The elements should be identical to the original " .. a:shape()["rows"] ..
+            " got instead " .. no_elmnts .. " elements")
 
   no_elmnts = 0
   head = a:head()
   for k,v in pairs(head) do
     if (#v > no_elmnts) then
-      no_elmnts = #v
+      no_elmnts = table.exact_length(v)
     end
   end
-  tester:eq(no_elmnts, a:shape()["rows"])
+  tester:eq(no_elmnts, a:shape()["rows"],
+            "The elements should be identical to the original " .. a:shape()["rows"] ..
+            " as the default is < original elements. Got instead " .. no_elmnts .. " elements")
 end
 
 function df_tests.tail()
@@ -327,7 +331,7 @@ function df_tests.tail()
       no_elmnts = l
     end
   end
-  tester:eq(no_elmnts, 2)
+  tester:eq(no_elmnts, 2, "Should have selected two last elements but got " .. no_elmnts)
 
   -- Only 4 rows and thus all should be included
   no_elmnts = 0
@@ -338,7 +342,7 @@ function df_tests.tail()
       no_elmnts = l
     end
   end
-  tester:eq(no_elmnts, a:shape()["rows"])
+  tester:eq(no_elmnts, a:shape()["rows"], "Should have selected 20 las elements and returned the original length " .. a:shape()["rows"] .. ", not " .. no_elmnts)
 
   no_elmnts = 0
   tail = a:tail()
@@ -348,7 +352,7 @@ function df_tests.tail()
       no_elmnts = l
     end
   end
-  tester:eq(no_elmnts, a:shape()["rows"])
+  tester:eq(no_elmnts, a:shape()["rows"], "Default selection is bigger than the simple_short, you got " .. no_elmnts .. " instead of " .. a:shape()["rows"])
 end
 
 function df_tests.show()

--- a/tests/basic_tests.lua
+++ b/tests/basic_tests.lua
@@ -13,13 +13,6 @@ table.reduce = function (list, fn)
     end
     return acc
 end
-table.exact_length = function(tbl)
-  i = 0
-  for k,v in pairs(tbl) do
-    i = i + 1
-  end
-  return i
-end
 
 function df_tests.csv_test_correct_size()
    local a = Dataframe()
@@ -393,8 +386,6 @@ function df_tests.where()
   tester:eq(ret_val:get_column('Col A'), {2, 3})
   -- TODO: Should the where B not return two rows or just the first row?
 end
-
-
 
 function df_tests.update()
   local a = Dataframe()

--- a/tests/basic_tests.lua
+++ b/tests/basic_tests.lua
@@ -53,9 +53,10 @@ function df_tests.table_schema()
   local first = {1,2,3}
   local second = {"2","1","3"}
   local third = {"2","a","3"}
-  a:load_table{data={['firstColumn']=first,
-                     ['secondColumn']=second,
-                     ['thirdColumn']=third}}
+  data = {['firstColumn']=first,
+          ['secondColumn']=second,
+          ['thirdColumn']=third}
+  a:load_table{data=data}
   tester:eq(a.schema["firstColumn"], 'number')
   tester:eq(a.schema["secondColumn"], 'number')
   tester:eq(a.schema["thirdColumn"], 'string')

--- a/tests/column_order_tests.lua
+++ b/tests/column_order_tests.lua
@@ -1,0 +1,38 @@
+require "../Dataframe"
+local co_tests = torch.TestSuite()
+local tester = torch.Tester()
+
+function co_tests.csv_check_load_no()
+   local a = Dataframe()
+   a:load_csv{path = "simple_short.csv",
+              verbose = false}
+   tester:eq(a.column_order,
+            {[1] = "Col A",
+             [2] = "Col B",
+             [3] = "Col C"},
+            "The basic column_order fails to load")
+end
+
+function co_tests.table_check_load_no()
+  local a = Dataframe()
+  local first = {1,2,3}
+  local second = {"2","1","3"}
+  local third = {"2","a","3"}
+  local column_order = {[1] = 'firstColumn',
+                        [2] = 'secondColumn',
+                        [3] = 'thirdColumn'}
+  a:load_table{data={['firstColumn']=first,
+                     ['secondColumn']=second,
+                     ['thirdColumn']=third},
+               column_order = column_order}
+  tester:eq(a.column_order, column_order)
+
+  column_order[2] = nil
+  tester:assertError(a:load_table{data={['firstColumn']=first,
+                                       ['secondColumn']=second,
+                                       ['thirdColumn']=third},
+                                  column_order = column_order} )
+end
+
+tester:add(co_tests)
+tester:run()

--- a/tests/column_order_tests.lua
+++ b/tests/column_order_tests.lua
@@ -15,23 +15,56 @@ end
 
 function co_tests.table_check_load_no()
   local a = Dataframe()
-  local first = {1,2,3}
+  local first  = {1,2,3}
   local second = {"2","1","3"}
-  local third = {"2","a","3"}
-  local column_order = {[1] = 'firstColumn',
+  local third  = {"2","a","3"}
+  local column_order =
+    {[1] = 'firstColumn',
                         [2] = 'secondColumn',
                         [3] = 'thirdColumn'}
-  a:load_table{data={['firstColumn']=first,
-                     ['secondColumn']=second,
-                     ['thirdColumn']=third},
+  local data = {['firstColumn']=first,
+                 ['secondColumn']=second,
+                 ['thirdColumn']=third}
+  a:load_table{data=data,
                column_order = column_order}
   tester:eq(a.column_order, column_order)
 
   column_order[2] = nil
-  tester:assertError(a:load_table{data={['firstColumn']=first,
-                                       ['secondColumn']=second,
-                                       ['thirdColumn']=third},
-                                  column_order = column_order} )
+  tester:assertError(function()
+                    a:load_table{data=data,
+                                 column_order = column_order}
+                    end)
+end
+
+function co_tests.sub()
+   local a = Dataframe()
+   a:load_csv{path = "simple_short.csv",
+              verbose = false}
+
+   local org_shape = a:shape()
+   tester:eq(a:sub():shape(),
+             org_shape)
+   org_shape["rows"] = org_shape["rows"] - 1
+   tester:eq(a:sub(1, 3):shape(),
+             org_shape)
+   tester:eq(a:sub(2, 4):shape(),
+             org_shape)
+   tester:eq(a:sub(2, 4):get_column("Col A")[1], 2)
+end
+
+function co_tests.to_csv()
+  local a = Dataframe()
+  local first = {1,2,3}
+  local second = {"Wow this it's tricky","1,2","323."}
+  local third = {"\"","a\"a","3"}
+  data = {['firstColumn']=first,
+          ['secondColumn']=second,
+          ['thirdColumn']=third}
+  a:load_table{data=data}
+  a:to_csv{path = "tricky_csv.csv"}
+  a:load_csv{path = "tricky_csv.csv", verbose = false}
+  tester:assertTableEq(a.dataset, data)
+  os.remove("tricky_csv.csv")
 end
 
 tester:add(co_tests)

--- a/tests/realistic_29_row_data.csv
+++ b/tests/realistic_29_row_data.csv
@@ -1,0 +1,29 @@
+Filename,Gender,Weight,Comments
+/home/test/wow.png,Male,55.5,
+/home/test/wow2.png,Female,77,"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud ex"
+/home/test/wow3.png,Female,66,
+/home/test/wow4.png,Female,90,
+/home/test/wow5.png,Male,78,
+/home/test/wow2.png,Male,55,
+/home/test/wow3.png,Male,66,
+/home/test/wow4.png,Male,89,"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud ex"
+/home/test/wow5.png,Female,87,
+/home/test/wow2.png,Female,67,
+/home/test/wow3.png,Female,88,
+/home/test/wow4.png,Male,66,"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor"
+/home/test/wow5.png,Male,54,
+/home/test/wow2.png,Male,66,
+/home/test/wow3.png,Male,87,
+/home/test/wow4.png,Female,87,Lorem ipsum 
+/home/test/wow5.png,Female,57,
+/home/test/wow2.png,Female,67,"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud ex"
+/home/test/wow3.png,Male,55,
+/home/test/wow4.png,Male,76,
+/home/test/wow5.png,Male,88,
+/home/test/wow2.png,Male,99,
+/home/test/wow3.png,Female,111,"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud ex"
+/home/test/wow4.png,Female,44,
+/home/test/wow5.png,Female,56,
+/home/test/wow2.png,Male,88,
+/home/test/wow3.png,Male,99,
+/home/test/wow4.png,Male,99,

--- a/tests/visual_output.lua
+++ b/tests/visual_output.lua
@@ -1,0 +1,24 @@
+require "../Dataframe"
+
+-- A quick way to get a feeling for how the __tostring method works
+local a = Dataframe()
+a:load_csv{path = "simple_short.csv",
+           verbose = false}
+print("-- Simple table --")
+print(a)
+
+print("-- Advanced table --")
+a:load_csv{path = "advanced_short.csv",
+           verbose = false}
+print(a)
+
+print("-- Long table --")
+a:load_csv{path = "realistic_29_row_data.csv",
+           verbose = false}
+print(a)
+
+a.print.no_rows = 5
+print(a)
+
+a.print.no_rows = 20
+print(a)


### PR DESCRIPTION
Adds a numerically keyed table with the column names `self.colum_order`. Whenever outputting anything this table is traversed so that the order is always the same.

The fix also handles reading column order from a CSV and saving it in the correct order. The latter required basically that a large piece of csvigo had to be internalized.

This PR also adds a `__pairs` function (note that this should be `__pairs__` for serialization issues but it isn't fixed until later branches) and changes the `head`/`tail` to use the `sub` for consistency.

As the current output is not very table-like I've added a `__tostring` method (should be `__tostring__` and will be fixed in later branch) that outputs something that resembles a markdown table when working outside the iTorch environment. See tests/visual_output.lua for examples. 
